### PR TITLE
修复了一个错误

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -136,9 +136,9 @@ Requests 会自动为你解码 ``gzip`` 和 ``deflate`` 传输编码的响应数
 ::
 
     >>> from PIL import Image
-    >>> from io import StringIO
+    >>> from io import BytesIO
 
-    >>> i = Image.open(StringIO(r.content))
+    >>> i = Image.open(BytesIO(r.content))
 
 
 JSON 响应内容


### PR DESCRIPTION
如果使用StringIO，会得到一个类型异常的错误，r.content返回的是字节类型的，所以应该使用BytesIO。
