### PR TITLE
修复了参数个数错误的问题

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -393,7 +393,7 @@ Requests有一个钩子系统，你可以用来操控部分请求过程，或信
 
 ::
 
-    def print_url(r):
+    def print_url(r, *args, **kwargs):
         print(r.url)
 
 若执行你的回调函数期间发生错误，系统会给出一个警告。


### PR DESCRIPTION
如果不修改运行代码会得到一个：TypeError: print_url() got an unexpected keyword argument 'timeout'的错误。
没有看过之前的requests文档，但是我觉得可能是某个版本修改了他的参数个数，因为我注意到在它的源码中是这样写的：`_hook_data = hook(hook_data, **kwargs)` 所以可能至少print_url方法最少接收一个`response`和一个`**kwargs`，看了英文版的文档，上面还接收了一个`*args`，虽然不知道他是出于什么目的，但是保持一致总归是好的。
